### PR TITLE
#Add Code of Conduct #1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# CryptoTracker Project Code of Conduct
+
+## Welcome
+
+Welcome to the CryptoTracker repository! This project is part of the **Winter of Blockchain (WoB)** initiative and aims to provide an open-source platform for learning and contributing to blockchain technology. We are committed to maintaining a positive, inclusive, and harassment-free environment for everyone involved.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward others
+- Being respectful of differing opinions, viewpoints, and experiences
+- Gracefully accepting constructive feedback
+- Apologizing when mistakes are made, and learning from the experience
+- Focusing on what is best for the community
+
+Unacceptable behavior includes:
+
+- The use of sexualized language or imagery and unwelcome sexual attention
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Harassment in any form, including public or private harassment
+- Publishing others’ private information without explicit permission
+- Any other conduct which would reasonably be considered inappropriate in a professional setting
+
+## Project Specifics
+
+This repository focuses on building and implementing cryptocurrency features like **Cryptocurrency Price Prediction**. We encourage contributions that enhance the project and make it an educational platform for blockchain enthusiasts worldwide.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing standards of acceptable behavior and will take appropriate corrective action in response to any unacceptable behavior.
+
+Leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct. They may also take action to address anything they deem inappropriate.
+
+## Scope
+
+This Code of Conduct applies to all spaces managed by CryptoTracker, including GitHub repositories, communication channels, and public spaces where individuals represent the community.
+
+## Reporting Violations
+
+Instances of abusive, harassing, or unacceptable behavior may be reported by contacting the community leaders at **chauhanvansh313@gmail.com**. All complaints will be reviewed and addressed promptly and fairly.
+
+## Enforcement Guidelines
+
+Community leaders will follow these guidelines to determine the consequences for violations of this Code of Conduct:
+
+1. **Correction**: A private warning about the violation with clarity on why the behavior was inappropriate.
+2. **Warning**: A warning and temporary restrictions from interacting with the community.
+3. **Temporary Ban**: A temporary ban for serious violations.
+4. **Permanent Ban**: A permanent ban for repeated or severe violations.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available [here](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).


### PR DESCRIPTION
closes #1 

This is a PR raised to create a code of conduct markdown file for the CryptoTracker Repo as a part of WOB24 contributions. I have used the general template for reference and modified it based on the project/repo information. Email ID of the author of the project has been added for reporting purposes as a part of code of conduct regulations. Please review the PR and share the feedback. Also request to add wob24 label. Thank you for your review.