### PR TITLE
added dynamic green and red border color for list view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "chart.js": "^4.2.0",
         "framer-motion": "^8.4.3",
         "i18next": "^23.16.3",
+        "lucide-react": "^0.453.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
@@ -12570,6 +12571,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.453.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.453.0.tgz",
+      "integrity": "sha512-kL+RGZCcJi9BvJtzg2kshO192Ddy9hv3ij+cPrVPWSRzgCWCVazoQJxOjAwgK53NomL07HB7GPHW120FimjNhQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/lz-string": {
@@ -27011,6 +27021,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lucide-react": {
+      "version": "0.453.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.453.0.tgz",
+      "integrity": "sha512-kL+RGZCcJi9BvJtzg2kshO192Ddy9hv3ij+cPrVPWSRzgCWCVazoQJxOjAwgK53NomL07HB7GPHW120FimjNhQ==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chart.js": "^4.2.0",
     "framer-motion": "^8.4.3",
     "i18next": "^23.16.3",
+    "lucide-react": "^0.453.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Dashboard/List/index.js
+++ b/src/components/Dashboard/List/index.js
@@ -16,7 +16,7 @@ function List({ coin, delay }) {
   return (
     <a href={`/coin/${coin.id}`}>
       <motion.tr
-        className="list-row"
+        className={`list-row ${coin.price_change_percentage_24h < 0 && "list-row-red"}`}
         initial={{ opacity: 0, x: -50 }}
         whileInView={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.5, delay: delay }}

--- a/src/components/Dashboard/List/styles.css
+++ b/src/components/Dashboard/List/styles.css
@@ -12,9 +12,14 @@
 }
 
 .list-row:hover {
-  background-color: var(--darkgrey);
-  transition: all 0.3s;
-}
+    border: 2px solid var(--green);
+    transition: all 0.3s;
+  }
+
+  .list-row-red:hover {
+    border: 2px solid var(--red);
+    transition: all 0.3s;
+  }
 
 .list-row td {
   width: 20%;


### PR DESCRIPTION
Related issue : 
Issue : #119 

Description : 
The green & red colored borders to depict profit and loss has been extended to list section as well. Earlier this was only possible in grid section. This change overall improves the UI consistency of the webpage.

Before : 

https://github.com/user-attachments/assets/f8f35195-fd02-44ed-a0a6-1fcf24b9ee39

After : 

https://github.com/user-attachments/assets/54e056e5-498f-4daf-8d7c-efc5cec253cb

