### PR TITLE
fixed pagination color in both the themes

### DIFF
--- a/src/components/Dashboard/Pagination/index.js
+++ b/src/components/Dashboard/Pagination/index.js
@@ -9,15 +9,15 @@ export default function PaginationControlled({ page, handlePageChange }) {
       <Pagination
         sx={{
           "& .MuiPaginationItem-text": {
-            color: "#fff !important",
-            border: "1px solid var(--grey)",
+            color: "var(--pagination-text-color) !important",
+            border: "1px solid var(--pagination-border-color)",
           },
           "& .MuiPaginationItem-text:hover": {
-            backgroundColor: "transparent !important",
+            backgroundColor: "var(--pagination-hover-bg-color) !important",
           },
           "& .Mui-selected  ": {
-            backgroundColor: "var(--blue)",
-            borderColor: "var(--blue)",
+            backgroundColor: "var(--pagination-selected-bg-color)",
+            borderColor: "var(--pagination-selected-border-color)",
           },
           "& .MuiPaginationItem-ellipsis": {
             border: "none",

--- a/src/components/Dashboard/Pagination/styles.css
+++ b/src/components/Dashboard/Pagination/styles.css
@@ -4,3 +4,19 @@
   justify-content: center;
   margin: 3rem;
 }
+
+:root {
+    --pagination-text-color: #000;
+    --pagination-border-color: #ccc;
+    --pagination-hover-bg-color: #f0f0f0;
+    --pagination-selected-bg-color: #3498db;
+    --pagination-selected-border-color: #007bff;
+  }
+
+  [data-theme="dark"] {
+    --pagination-text-color: #fff;
+    --pagination-border-color: #444;
+    --pagination-hover-bg-color: transparent;
+    --pagination-selected-bg-color: #3498db;
+    --pagination-selected-border-color: #3498db;
+  }


### PR DESCRIPTION
Related issue : 
Fixes : #155 

Description : 
Page no. text in dashboard was not clearly visible in light theme. I added some custom CSS to specifically handle Pagination title under both the themes.

Screenshots : 
Before : 
![Screenshot from 2024-10-29 05-10-50](https://github.com/user-attachments/assets/8c9ca123-5c62-40ec-8eb6-75589d8430b7)

After : 
![Screenshot from 2024-10-29 05-29-30](https://github.com/user-attachments/assets/f0bc85c1-d95b-43cd-91a4-b3ec0e55aa5b)

![image](https://github.com/user-attachments/assets/1fd851b5-9749-46fa-b4c8-3d34e29b6afa)
