### PR TITLE
fixed list glitch and added background color

### DIFF
--- a/src/components/Dashboard/List/styles.css
+++ b/src/components/Dashboard/List/styles.css
@@ -9,6 +9,8 @@
   margin-right: auto;
   border-radius: 0.8rem;
   cursor: pointer;
+  background-color: var(--darkgrey);
+  border: 2px solid var(--darkgrey);
 }
 
 .list-row:hover {


### PR DESCRIPTION
Realted issue : 
Fixes : #157 

Description : 
1) The list view under dashboard when hovered creates a kind of glitch which seems like the border is expanding in size a bit after a sec and that appears non-smooth unlike in grid section.
Solution : Added border of 2px soild var(--darkgrey)
Before : 

https://github.com/user-attachments/assets/dfa7722f-dcbb-4a15-bc37-94ed1b22f800

After : 

https://github.com/user-attachments/assets/2af6c785-258a-4945-a50d-0ee5b95d0f7a


2) Also, there is unevenness in UI of both grid and list making it non-consistent (like no background color in list in both light and dark mode)
Solution : Added background-color as var(--darkgrey)

Before : 
![image](https://github.com/user-attachments/assets/f44a6138-e768-44e2-85a7-f551049bdd46)

![image](https://github.com/user-attachments/assets/e914bac2-f540-4e6e-8113-f5ea49f40441)

After : 
![image](https://github.com/user-attachments/assets/94543d77-df28-4366-ae4f-ece66f531307)

![image](https://github.com/user-attachments/assets/08d56b46-3bae-469c-85d2-7c2719175406)
