### PR TITLE
Fix hero section and footer overlapping issue

### DIFF
--- a/src/components/LandingPage/MainComponent/styles.css
+++ b/src/components/LandingPage/MainComponent/styles.css
@@ -38,6 +38,7 @@
 
 .heading2 {
   color: var(--blue);
+  margin-top: -5px; 
 }
 
 .info-text {
@@ -61,8 +62,8 @@
 
 .gradient {
   position: relative;
-  left: 18.75rem;
-  top: 3.75rem;
+  left: 18.5rem;
+  top: 3rem;
   width: 15.625rem;
 }
 
@@ -181,7 +182,7 @@ clamp(minFontSize, ratio, maxFontSize)
     }
     
   .main-wrapper {
-    padding-bottom: 50px; /* Reduce padding on mobile */
+    padding-bottom: 60px; /* Reduce padding on mobile */
   }
   
     /* .iphone {


### PR DESCRIPTION
#169 solved

The hero section and footer are currently overlapping, resulting in a cluttered appearance that disrupts the layout flow and user experience. This fix ensures proper spacing and alignment between the hero section and footer, preventing overlap and maintaining a clean, organized look across the page.

![image](https://github.com/user-attachments/assets/210aa70e-ebbe-42b8-b87a-d80556330ab0)
