### PR TITLE
Align hero section correctly in mobile view

### DIFF
--- a/src/components/LandingPage/MainComponent/styles.css
+++ b/src/components/LandingPage/MainComponent/styles.css
@@ -108,7 +108,7 @@
 
   .heading1,
   .heading2 {
-    font-size: 2rem;
+    font-size: 3rem;
   }
 
   .main-flex {
@@ -124,7 +124,7 @@
   }
 
   .info-text {
-    font-size: 0.8rem;
+    font-size: 0.9rem;
   }
 
   .btn-flex {
@@ -143,11 +143,16 @@
     left: 0px;
     right: 0px;
   }
-
+  .gradient {
+    right: 0px;
+    top: 60px;
+    width: 200px;
+    height: 50%;
+  }
   .iphone {
-    width: 80%; /* Make it responsive */
-    max-width: 250px; /* Maintain a max width */
-    top: 10px; /* Adjust top positioning for mobile */
+    width: 95%; 
+    max-width: 400px; 
+    top: 20px; 
   }
 }
 
@@ -203,16 +208,6 @@ clamp(minFontSize, ratio, maxFontSize)
     padding:3rem 3rem 1rem;
     position: relative;
   }
-  .info-landing {
-    max-width: 50%; /* Limit width to prevent overlapping with iPhone */
-    padding-right: 2rem; /* Add some padding to the right */
-  }
-
-    /* .iphone {
-      left: -20px;
-    } */
-
-
 /* Custom CSS styling for share App dialog box */
 
 .rws-backdrop {


### PR DESCRIPTION
#172 fixed

The hero section on the mobile version is not centered properly, causing a misaligned and off-centered appearance that detracts from the visual appeal. This fix ensures that the hero section aligns centrally on mobile devices, providing a consistent and visually balanced layout that enhances the user experience on smaller screens.

![image](https://github.com/user-attachments/assets/554b430f-0c6e-487c-a3ff-01707fd77938)
