### PR TITLE
Improve "Real Time" text visibility in Dark Mode

### DIFF
--- a/src/components/LandingPage/MainComponent/styles.css
+++ b/src/components/LandingPage/MainComponent/styles.css
@@ -18,6 +18,9 @@
   font-size: 6rem;
   margin: 0;
 }
+.heading1{
+  color: var(--black) !important;
+}
 
 
 /* .heading1:hover {
@@ -28,13 +31,13 @@
 } */
 
 
-[data-theme="dark"] .heading1 {
+/* [data-theme="dark"] .heading1 {
   color: var(--heading1-color-dark);
 }
 
 [data-theme="light"] .heading1 {
   color: var(--heading1-color-light);
-}
+} */
 
 .heading2 {
   color: var(--blue);


### PR DESCRIPTION
fixed #192 
please add label level 3 if possible 

This PR addresses a readability issue on the home page in Dark Mode, where the "Real Time" text was difficult to see due to low contrast with the background. The color has been adjusted to ensure sufficient contrast, improving text visibility and enhancing user experience across display modes.

![image](https://github.com/user-attachments/assets/7fb03320-4f4b-4bc8-8f95-49ff3b2fbf44)

