### PR TITLE
Improved  darkmode on privacypolicy page

### DIFF
--- a/src/pages/Privacy-Policy/PrivacyPolicy.css
+++ b/src/pages/Privacy-Policy/PrivacyPolicy.css
@@ -3,8 +3,8 @@ body {
     margin: 0;
     padding: 0;
     font-family: 'Arial', sans-serif;
-    background-color: #f8f9fa;
-    color: #333;
+    background-color: var(--privacy-bg-color);
+    color: var(--privacy-text-color);
   }
   
   /* Container Styles */
@@ -12,9 +12,11 @@ body {
     max-width: 800px;
     margin: 50px auto;
     padding: 20px;
-    background-color: #fff;
+    background-color: var(--privacy-bg-color);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     border-radius: 8px;
+    color: var(--privacy-text-color);
+    transition: border 0.3s ease;
   }
   
   Header
@@ -63,6 +65,7 @@ body {
   
   a:hover {
     text-decoration: underline;
+    color: #0056b3;
   }
   
   /* Responsive Design */
@@ -81,3 +84,21 @@ body {
     }
   }
   
+  :root {
+    --privacy-bg-color: #f9f9f9;
+    --privacy-text-color: #333;
+  }
+  
+  [data-theme="dark"] {
+    --privacy-bg-color: #121212;
+    --privacy-text-color: #f5f5f5;
+  }
+  .h1, .h2 {
+    color: var(--privacy-text-color);
+  }
+  p, li {
+    color: var(--privacy-text-color);
+  }
+  [data-theme="dark"] .container {
+    border: 2px solid #3a80e9; /* Blue outline in dark mode */
+  }


### PR DESCRIPTION
fixed #203 
This update brings dark mode support to the Privacy Policy page, enhancing user experience for those browsing in low-light conditions. The theme toggle seamlessly adapts the page’s appearance to align with the rest of the site’s dark mode styling, improving readability and comfort.

https://github.com/user-attachments/assets/308fc5a6-7851-42bc-9102-21cc1aceead9

