### PR TITLE
added copyright claims

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -198,6 +198,21 @@ const Footer = () => {
       >
         <GoogleTranslate />
       </div>
+      <div
+        className="flex"
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          width: "100%",
+          marginTop: "1rem",
+          marginBottom: "0.5rem",
+          fontSize: "0.9rem",
+          color: "#ffffff",
+        }}
+      >
+        <text>© 2024 CryptoTracker. All rights reserved.</text>
+      </div>
     </footer>
   );
 };


### PR DESCRIPTION
Related issue
Fixed #212 

Description : 
Added copyright for CryptoTracker in the footer section

Screenshot : 
Before : 
![image](https://github.com/user-attachments/assets/c18ea06f-5158-425c-b1c9-e71548e79b4f)

After : 
![image](https://github.com/user-attachments/assets/a76b42ce-ee01-49be-9f37-dabe37b4aab4)

Please review my PR and label it under WoB, GSSoC and Hacktoberfest