### PR TITLE
added dark mode support for pricing section

### DIFF
--- a/src/pages/Pricing/Pricing.css
+++ b/src/pages/Pricing/Pricing.css
@@ -1,27 +1,39 @@
 .pricing-container {
-    max-width: 1200px;
-    margin: 50px auto;
-    padding: 20px;
+    display: flex;
+    flex-direction: column !important;
+    justify-content: center;
+    align-items: center;
+    max-width: fit-content;
+    margin: auto;
     text-align: center;
-    background-color: #f9f9f9;
+    background-color: var(--pricing-container-bg-color) !important;
   }
-  
+
+[data-theme='dark'] {
+    --pricing-container-bg-color: #121212;
+  }
+
+  [data-theme='light'] {
+    --pricing-container-bg-color: #f5f5f5;
+  }
+
   .card-container {
     display: flex;
-    justify-content: space-around;
+    flex-direction: row !important;
+    justify-content: center !important;
+    align-items: center !important;
     flex-wrap: wrap;
     gap: 20px;
     margin-top: 30px;
   }
-  
+
   @media (max-width: 768px) {
     .card-container {
       flex-direction: column;
       align-items: center;
     }
-  
+
     .card {
       width: 90%;
     }
   }
-  


### PR DESCRIPTION
Related issue 
Fixed #240 

Description : 
Added dark mode theme for pricing section using custom CSS for different themes

Screenshots : 
Before : 
![image](https://github.com/user-attachments/assets/bae81e54-b663-4032-a4c8-04991ba0fca1)

After : 
![image](https://github.com/user-attachments/assets/f11632ac-15fb-4677-8699-cc8e0e70da7c)

![image](https://github.com/user-attachments/assets/f9337662-9837-45d4-a634-778baedebe6a)
