### PR TITLE
fixed clerk authenticator default URL problem

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -37,7 +37,47 @@ export default function SignInPage() {
       >
         <i className="fas fa-home" style={{ fontSize: "24px", color: "#333" }}></i>
       </div>
-      <SignIn />
+      <div style={{ position: "relative" }}>
+      <SignIn
+        appearance={{
+          elements: {
+            footerActionLink: {
+              display: "none",
+            },
+          },
+        }}
+      />
+      <div
+        style={{
+            position: "absolute",
+            bottom: "5rem",
+            width: "100%",
+            textAlign: "center",
+            fontSize: "14px",
+            color: "#333",
+        }}
+      >
+        <span>Don't have an account? </span>
+        <a
+          href="/signup"
+          style={{
+            color: "#3a80e9",
+            textDecoration: "none",
+            fontWeight: "bold",
+            fontSize: "0.7rem",
+          }}
+        >
+          Sign up
+        </a>
+      </div>
+    </div>
+    <style>
+        {`
+          .cl-footerActionText {
+            display: none !important;
+          }
+        `}
+      </style>
     </div>
   );
 }

--- a/src/pages/Signup.js
+++ b/src/pages/Signup.js
@@ -37,7 +37,46 @@ export default function SignUpPage() {
       >
         <i className="fas fa-home" style={{ fontSize: "24px", color: "#333" }}></i>
       </div>
-      <SignUp />
+      <div style={{ position: "relative" }}>
+        <SignUp
+          appearance={{
+            elements: {
+              footerActionLink: {
+                display: "none",
+              },
+            },
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: "5rem",
+            width: "100%",
+            textAlign: "center",
+            fontSize: "14px",
+            color: "#333",
+          }}
+        >
+          <span>Already have an account? </span>
+          <a
+            href="/login"
+            style={{
+              color: "#3a80e9",
+              textDecoration: "none",
+              fontWeight: "bold",
+            }}
+          >
+            Sign in
+          </a>
+        </div>
+      </div>
+      <style>
+        {`
+          .cl-footerActionText {
+            display: none !important;
+          }
+        `}
+      </style>
     </div>
   );
 }


### PR DESCRIPTION
#### Issue Title
Fixed #272 

- [x] I have provided the issue title.

---

#### Info about the Related Issue
The Sign up link in "doesn't have an account" redirects by default to [accounts.dev/sign-up](https://noted-terrier-69.accounts.dev/sign-up) whereas it should redirect to [/signup](https://crypto-tracker-kappa-ebon.vercel.app/signup) .The same goes for login link in signup page.

- [x] I have described the aim of the project.

---

#### Name
Irtesaam Atfi

- [x] I have provided my name.

---

#### GitHub ID
irtesaam

- [x] I have provided my GitHub ID.

---

#### Identify Yourself
GSSoC
WoB
Hacktoberfest

- [x] I have mentioned my participant role.

---

#### Closes
Closes: #272 

- [x] I have provided the issue number.

---

#### Describe the Add-ons or Changes You've Made
The problem lies in the default URL set by Clerk authenticator used in the website.
So I overwrite those default URLs using Javascript appearance and href keys and pointed the new link to the /signup and /login page which are already present in the codebase.
Also , I have used custom CSS properties to position the new texts and link at the correct location on the login and signup page.

- [x] I have described my changes.

---

#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

#### How Has This Been Tested?
Notice the page URLs before and after the changes.
Before : 

https://github.com/user-attachments/assets/b5ab7543-8280-48ad-bc2d-c1c90fee867d

After : 

https://github.com/user-attachments/assets/a491b9d9-ed1d-496f-9db5-6eb8b6714335

- [x] I have described my testing process.

---

#### Checklist
**Please confirm the following:**  
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added things that prove my fix is effective or that my feature works.
