### PR TITLE
fixed heading text blending in dark mode

### DIFF
--- a/src/components/LandingPage/MainComponent/styles.css
+++ b/src/components/LandingPage/MainComponent/styles.css
@@ -18,9 +18,6 @@
   font-size: 6rem;
   margin: 0;
 }
-.heading1{
-  color: var(--black) !important;
-}
 
 
 /* .heading1:hover {
@@ -41,7 +38,7 @@
 
 .heading2 {
   color: var(--blue);
-  margin-top: -5px; 
+  margin-top: -5px;
 }
 
 .info-text {
@@ -153,9 +150,9 @@
     height: 50%;
   }
   .iphone {
-    width: 95%; 
-    max-width: 400px; 
-    top: 20px; 
+    width: 95%;
+    max-width: 400px;
+    top: 20px;
   }
 }
 
@@ -188,22 +185,22 @@ clamp(minFontSize, ratio, maxFontSize)
       margin-top: 80px; /* Adjust margin for mobile */
       margin: 1.5rem 0.5rem;
     }
-    
+
   .main-wrapper {
     padding-bottom: 60px; /* Reduce padding on mobile */
   }
-  
+
     /* .iphone {
       left: -20px;
     } */
-  } 
+  }
 
   .main-wrapper {
     min-height: 80vh;
     position: relative;
     padding-bottom: 20px; /* Add padding to prevent footer overlap */
   }
-  
+
   .main-flex {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
#### Issue Title
Fixed #274 

- [x] I have provided the issue title.

---

#### Info about the Related Issue
"Real Time" is not visible in dark mode because a CSS property with high precedence was overwriting the default one.

- [x] I have described the aim of the project.

---

#### Identify Yourself
GSSoC
WoB
Hacktoberfest

- [x] I have mentioned my participant role.

---

#### Closes
Closes  #274 

- [x] I have provided the issue number.

---

#### Describe the Add-ons or Changes You've Made
Removed the contradicting CSS property color: var(--black) !important; and added a var(--heading1-color) which will adjust as per theme

- [x] I have described my changes.

---

#### Type of Change
**Select the type of change:**  
- [x] Bug fix (non-breaking change which fixes an issue)

---

#### How Has This Been Tested?
Before : 

https://github.com/user-attachments/assets/32db1ccb-d4ca-4746-8494-745fa224f4c9

After : 

https://github.com/user-attachments/assets/005932c8-c46c-41e0-888c-11e8d2af672c

- [x] I have described my testing process.

---

#### Checklist
**Please confirm the following:**  
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added things that prove my fix is effective or that my feature works.
