### PR TITLE
Enhance Contrast for Crypto Converter in Dark Mode

### DIFF
--- a/src/pages/CryptoConverter.css
+++ b/src/pages/CryptoConverter.css
@@ -63,3 +63,23 @@
   color: #0a0a0a;
   text-align: center;
 }
+
+/* Add these rules to your CryptoConverter.css file */
+
+/* Styles for dark mode */
+[data-theme="dark"] .input-field,
+[data-theme="dark"] .dropdown {
+  color: black;
+  background-color: #f0f0f0; /* Light background for contrast */
+}
+
+/* Ensure the placeholder text is also visible */
+[data-theme="dark"] .input-field::placeholder {
+  color: #666;
+}
+
+/* Optionally, you can style the dropdown options as well */
+[data-theme="dark"] .dropdown option {
+  background-color: #f0f0f0;
+  color: black;
+}


### PR DESCRIPTION
fixed #267 

1. Addressed visibility issue in the crypto converter by improving text and background contrast in dark mode.
2. Adjusted color scheme to ensure clear readability, enhancing user experience and usability when dark mode is enabled.
3. This update ensures that content is fully visible and accessible, aligning with the dark theme across the site.

![image](https://github.com/user-attachments/assets/077c3c6a-1c9c-4a0b-84e1-d8dfe29af3a3)
