### PR TITLE
integrated dark mode theme in crypto profit calculator

### DIFF
--- a/src/pages/CryptoProfitCalculator.js
+++ b/src/pages/CryptoProfitCalculator.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-// import "./CryptoProfitCalculator.css"; 
+// import "./CryptoProfitCalculator.css";
 import Header from "../components/Common/Header";
 
 function CryptoProfitCalculator() {
@@ -13,7 +13,7 @@ function CryptoProfitCalculator() {
       alert("Please fill in all fields.");
       return;
     }
-    
+
     const profitOrLoss = ((currentPrice - buyPrice) / buyPrice) * 100;
     const profitOrLossAmount = (initialInvestment * profitOrLoss) / 100;
     setResult({
@@ -23,36 +23,36 @@ function CryptoProfitCalculator() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-950 flex flex-col">
       <Header />
       <div className="flex flex-col items-center justify-center flex-1 p-6">
-        <div className="bg-white rounded-lg shadow-lg p-8 max-w-md w-full">
-          <h2 className="text-2xl font-semibold mb-6 text-gray-800 text-center">Crypto Profit Calculator</h2>
+        <div className="bg-white dark:bg-black rounded-lg shadow-lg p-8 max-w-md w-full">
+          <h2 className="text-2xl font-semibold mb-6 text-gray-800 dark:text-gray-400 text-center">Crypto Profit Calculator</h2>
           <div className="mb-4">
-            <label className="block text-gray-600 mb-2">Initial Investment ($)</label>
+            <label className="block text-gray-600 dark:text-gray-500 mb-2">Initial Investment ($)</label>
             <input
               type="number"
               value={initialInvestment}
               onChange={(e) => setInitialInvestment(e.target.value)}
-              className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="w-full p-2 border text-gray-300 dark:bg-gray-950 border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
             />
           </div>
           <div className="mb-4">
-            <label className="block text-gray-600 mb-2">Buy Price ($)</label>
+            <label className="block text-gray-600 dark:text-gray-500 mb-2">Buy Price ($)</label>
             <input
               type="number"
               value={buyPrice}
               onChange={(e) => setBuyPrice(e.target.value)}
-              className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="w-full p-2 border text-gray-300 dark:bg-gray-950 border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
             />
           </div>
           <div className="mb-4">
-            <label className="block text-gray-600 mb-2">Current Price ($)</label>
+            <label className="block text-gray-600 dark:text-gray-500 mb-2">Current Price ($)</label>
             <input
               type="number"
               value={currentPrice}
               onChange={(e) => setCurrentPrice(e.target.value)}
-              className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="w-full p-2 border text-gray-300 dark:bg-gray-950 border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
             />
           </div>
           <button
@@ -63,9 +63,9 @@ function CryptoProfitCalculator() {
           </button>
 
           {result && (
-            <div className="mt-6 p-4 bg-gray-100 rounded-md border border-gray-300">
-              <p className="text-lg text-gray-800 font-medium">Profit/Loss Percentage: <span className={result.percentage >= 0 ? "text-green-600" : "text-red-600"}>{result.percentage}%</span></p>
-              <p className="text-lg text-gray-800 font-medium">Profit/Loss Amount: <span className={result.amount >= 0 ? "text-green-600" : "text-red-600"}>${result.amount}</span></p>
+            <div className="mt-6 dark:bg-gray-900 p-4 bg-gray-100 rounded-md border border-gray-300">
+              <p className="text-lg dark:text-gray-400 font-medium">Profit/Loss Percentage: <span className={result.percentage >= 0 ? "text-green-600" : "text-red-600"}>{result.percentage}%</span></p>
+              <p className="text-lg dark:text-gray-400 font-medium">Profit/Loss Amount: <span className={result.amount >= 0 ? "text-green-600" : "text-red-600"}>${result.amount}</span></p>
             </div>
           )}
         </div>


### PR DESCRIPTION
#### Issue Title
Fixed #329 

- [x] I have provided the issue title.

---

#### Info about the Related Issue
There was no dark mode theme available for Crypto Profit calculator

- [x] I have described the aim of the project.

---

#### Name
Irtesaam

- [x] I have provided my name.

---

#### GitHub ID
irtesaam

- [x] I have provided my GitHub ID.

---

#### Identify Yourself
GSSoC
WoB
Hacktoberfest

- [x] I have mentioned my participant role.

---

#### Closes
*Closes: #329 *

- [x] I have provided the issue number.

---

#### Describe the Add-ons or Changes You've Made
integrated dark mode theme in crypto profit calculator using Tailwind predefined classes for dark themes.

- [x] I have described my changes.

---

#### Type of Change
**Select the type of change:**  
- [x] New feature (non-breaking change which adds functionality)

---

#### How Has This Been Tested?
Before : 

https://github.com/user-attachments/assets/0dc562ff-c6b7-4b64-a978-502ec560ebfb

After : 

https://github.com/user-attachments/assets/32db9b59-6ba8-48a6-83c8-31d38c23913b

- [x] I have described my testing process.

---

#### Checklist
**Please confirm the following:**  
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added things that prove my fix is effective or that my feature works.