### PR TITLE
Fix background color mismatch for GitHub and Visitor Count frames to match footer

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -247,8 +247,8 @@ const Footer = () => {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  backgroundColor: "#d3d3d3", // Light gray background
-                  color: "#333",
+                  backgroundColor: "rgba(255, 255, 255, 0.15)", 
+                  color: "#fff",
                   padding: "10px",
                   borderRadius: "8px",
                   width: "100%", // Match parent width (150px)
@@ -261,14 +261,14 @@ const Footer = () => {
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{
-                    color: "#333",
+                    color: "#fff",
                     textDecoration: "none",
                     fontWeight: "bold",
                   }}
                 >
                   Star Us ⭐
                 </a>
-                <span style={{ marginLeft: "8px" }}>{stars}</span>
+                <span style={{ marginLeft: "8px", color: "#fff" }}>{stars}</span>
               </div>
 
 
@@ -319,8 +319,8 @@ const Footer = () => {
             flexDirection: "column",      // Stack image and text vertically
             alignItems: "center",
             justifyContent: "center",
-            backgroundColor: "#d3d3d3",
-            color: "#333",
+            backgroundColor: " rgba(255, 255, 255, 0.15)",
+            color: "#fff",
             padding: "10px 20px",
             borderRadius: "8px",
             boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.2)",
@@ -333,7 +333,7 @@ const Footer = () => {
             alt="Visit counter"
             style={{ border: "none", marginBottom: "8px" }} // Add margin below image
           />
-          <span style={{ fontWeight: "bold", fontSize: "16px" }}>
+          <span style={{ fontWeight: "bold", fontSize: "16px", color: "#fff" }}>
             Visitors Count
           </span>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -401,8 +401,7 @@ h3,
 h4,
 h5,
 h6,
-p,
-span {
+p{
   color: var(--text-color);
 }
 


### PR DESCRIPTION

#### Issue Title
Fix background color mismatch for GitHub and Visitor Count frames to match footer

- [ ] I have provided the issue title.

---

#### Info about the Related Issue
The GitHub and Visitor Count frames currently have a background color that doesn’t match the footer’s background, creating an inconsistent visual appearance. This update aligns the background color of these frames with the footer's color scheme to ensure a cohesive look across all page elements. Matching the colors will improve the page's visual flow, enhancing user experience with a uniform design.

- [ ] I have described the aim of the project.

---

#### Closes
**Enter the issue number that will be closed through this PR.**  
*Closes: #360*

---
![image](https://github.com/user-attachments/assets/a7df196d-1435-4394-82ec-205bb871aad1)
