### PR TITLE
Content visibility in dark mode 

### DIFF
--- a/src/pages/ImpermanentLossCalculator.css
+++ b/src/pages/ImpermanentLossCalculator.css
@@ -2,7 +2,7 @@
   border: 1px solid #201f1f;
   padding: 30px;
   border-radius: 9px;
-  background-color: #f9f9f9;
+  background-color: var(--calculator-bg);
   max-width: 600px;
   margin: 20px auto;
   text-align: center;
@@ -45,4 +45,62 @@
 
 .result {
   font-size: 1.3rem;
+}
+
+[data-theme="dark"] {
+  --calculator-bg: #222020;
+  --calculator-text: #ffffff;
+  --calculator-border: #3a80e9;
+  --calculator-input-bg: #2c2c2c;
+  --calculator-input-text: #ffffff;
+  --calculator-input-border: #3a80e9;
+}
+[data-theme="light"] {
+  --calculator-bg: #f9f9f9;
+  --calculator-text: #201f1f;
+  --calculator-border: #1528ee;
+  --calculator-input-bg: #ffffff;
+  --calculator-input-text: #201f1f;
+  --calculator-input-border: #1528ee;
+}
+.calculator h2 {
+  margin-bottom: 30px;
+  color: var(--calculator-text);
+}
+
+.calculator label {
+  display: block;
+  margin: 10px 0 5px;
+  font-size: 1.3rem;
+  color: var(--calculator-text);
+}
+
+.calculator input {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 15px;
+  border: 1px solid var(--calculator-input-border);
+  border-radius: 6px;
+  background-color: var(--calculator-input-bg);
+  color: var(--calculator-input-text);
+}
+
+.calculator button {
+  padding: 15px 30px;
+  background-color: #070be3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.calculator button:hover {
+  background-color: #babef0;
+  color: #201f1f;
+  border: 1px solid blue;
+}
+
+.result {
+  font-size: 1.3rem;
+  color: var(--calculator-text);
 }


### PR DESCRIPTION
fixed #349 

The content of Impermanent Loss Calculator is now visible in dark mode 

![image](https://github.com/user-attachments/assets/1c6ca8d6-d923-4ccd-a01a-82d0282bfd29)
