### PR TITLE
[Feature]: Add BTC Dominance Chart and Key Market Stats Section

### DIFF
--- a/src/components/MarketStats/MarketStats.css
+++ b/src/components/MarketStats/MarketStats.css
@@ -1,0 +1,82 @@
+:root {
+    --blue: #0066ff;
+    --grey: #a0a3a8;
+    --black: #121212;
+    --white: #f5f5f5;
+    --card-bg-light: #ffffff;
+    --card-bg-dark: #1f1f1f;
+    --shadow-color-light: rgba(0, 0, 0, 0.1);
+    --shadow-color-dark: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] {
+    --background-color: var(--black);
+    --text-color: var(--white);
+    --card-bg: var(--card-bg-dark);
+    --shadow-color: var(--shadow-color-dark);
+}
+
+[data-theme="light"] {
+    --background-color: var(--white);
+    --text-color: var(--black);
+    --card-bg: var(--card-bg-light);
+    --shadow-color: var(--shadow-color-light);
+}
+
+
+.market-stats {
+    padding: 20px;
+    text-align: center;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    border-radius: 8px;
+
+    box-shadow: 0 2px 8px rgba(99, 40, 182, 0.636);
+    margin: 1rem 3rem;
+    transition: transform 0.3s ease, border-radius 0.3s ease, background-color 3s ease; /* Smooth transitions for transform, border-radius, and background-color */
+
+}
+
+.market-stats:hover {
+    
+    transform: translateY(-10px); /* Moves the card slightly upwards on hover */
+    border-radius: 8px; /* Slightly rounded corners on hover */
+    background: linear-gradient(135deg, #6a5acd, #1e90ff); /* Smooth gradient for background */
+    transition: background 3s ease; /* Slow background change */
+}
+
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.stat-card {
+    padding: 15px;
+    background-color: var(--card-bg);
+    border: 1px solid var(--grey);
+    border-radius: 8px;
+    box-shadow: 0 4px 8px var(--shadow-color);
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.stat-card h3 {
+    font-size: 1.2em;
+    color: var(--text-color);
+    margin-bottom: 10px;
+}
+
+.stat-card p {
+    font-size: 1.1em;
+    color: var(--blue);
+    font-weight: bold;
+}
+
+.about-bitcoin {
+    margin-top: 20px;
+    color: var(--text-color);
+    font-size: 0.9em;
+    line-height: 1.5;
+}

--- a/src/components/MarketStats/MarketStats.js
+++ b/src/components/MarketStats/MarketStats.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import './MarketStats.css';
+
+const MarketStats = () => {
+    const [marketData, setMarketData] = useState({
+        btcDominance: 0,
+        totalMarketCap: 0,
+        volume24h: 0,
+        altcoinShare: 0,
+    });
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchMarketData = async () => {
+            try {
+                const response = await axios.get('https://api.coingecko.com/api/v3/global');
+                const data = response.data.data;
+
+                setMarketData({
+                    btcDominance: parseFloat(data.market_cap_percentage.btc).toFixed(2),
+                    totalMarketCap: data.total_market_cap.usd,
+                    volume24h: data.total_volume.usd,
+                    altcoinShare: parseFloat(100 - data.market_cap_percentage.btc).toFixed(2),
+                });
+                setLoading(false);
+            } catch (error) {
+                setError("Error fetching market data. Please try again later.");
+                setLoading(false);
+            }
+        };
+
+        fetchMarketData();
+    }, []);
+
+    const formatNumber = (num) => {
+        return new Intl.NumberFormat('en-US', { notation: 'compact', compactDisplay: 'short' }).format(num);
+    };
+
+    return (
+        <div className="market-stats">
+            {loading ? (
+                <p>Loading market data...</p>
+            ) : error ? (
+                <p>{error}</p>
+            ) : (
+                <div className="stats-grid">
+                    <div className="stat-card">
+                        <h3>BTC Dominance</h3>
+                        <p>{marketData.btcDominance}%</p>
+                    </div>
+                    <div className="stat-card">
+                        <h3>Total Market Cap</h3>
+                        <p>${formatNumber(marketData.totalMarketCap)}</p>
+                    </div>
+                    <div className="stat-card">
+                        <h3>24-Hour Volume</h3>
+                        <p>${formatNumber(marketData.volume24h)}</p>
+                    </div>
+                    <div className="stat-card">
+                        <h3>Altcoin Market Share</h3>
+                        <p>{marketData.altcoinShare}%</p>
+                    </div>
+                </div>
+            )}
+
+            <div className='about-bitcoin'>
+                <p>The Bitcoin Dominance Indicator measures Bitcoin’s share of the overall cryptocurrency market. A high BTC dominance often suggests that investors favor Bitcoin over altcoins, typically reflecting stability or risk aversion in the market. A lower dominance can signal increased interest in altcoins, with investors potentially seeking diversification.</p>
+            </div>
+        </div>
+    );
+};
+
+export default MarketStats;

--- a/src/pages/BTCDominance/BTCDominance.js
+++ b/src/pages/BTCDominance/BTCDominance.js
@@ -13,6 +13,7 @@ import {
   Legend,
   Filler,
 } from "chart.js";
+import MarketStats from "../../components/MarketStats/MarketStats";
 
 ChartJS.register(
   CategoryScale,
@@ -154,6 +155,9 @@ function BTCDominance() {
           </div>
         </div>
       </div>
+
+
+      <MarketStats/>
     </>
   );
 }


### PR DESCRIPTION
This PR introduces a new component, MarketStats, to display key market statistics including Bitcoin dominance, total market capitalization, 24-hour trading volume, and altcoin market share. The component fetches real-time data from the CoinGecko API and displays the information in a clean, responsive layout. It also includes explanations for each stat to provide users with a clearer understanding of Bitcoin dominance in the market.


'fixed #485 ' @vanshchauhan21  done


https://github.com/user-attachments/assets/1d0e72c9-45d3-463f-a6f2-8adfa549fbe5

