### PR TITLE
Add Routing and Content for Earn Page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,6 +71,7 @@ import GeminiChat from "./pages/GeminiAIChat/GeminiAIChat.jsx";
 import CryptoReward from "./pages/Cryptoreward/Cryptoreward.js";
 
 import FearAndGreedIndex from './pages/FearAndGreedIndex/FearAndGreedIndex';
+import Earn from "./pages/Earn/Earn.js";
 
 
 
@@ -162,6 +163,8 @@ function App() {
                 <Route path="/pricing" element={<Pricing />} />
                 <Route path="/Contributors" element={<Contributors />} />
                 <Route path="/blog" element={<Blog />} />
+              
+                <Route path="/earn" element={<Earn />} />
 
 
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -96,7 +96,7 @@ const Footer = () => {
               { path: "/compare", label: "Compare" },
               { path: "/watchlist", label: "Watchlist" },
               { path: "/dashboard", label: "Dashboard" },
-              { path: "/#", label: "Earn" },
+              { path: "/earn", label: "Earn" },
               { path: "/#", label: "Blog" },
               { path: "/faq", label: "FAQ" },
               { path: "/pricing", label: "Pricing" },

--- a/src/pages/Earn/Earn.css
+++ b/src/pages/Earn/Earn.css
@@ -1,0 +1,23 @@
+.earn-container {
+    padding: 2rem;
+  }
+  
+  .earn-description {
+    font-size: 1.1rem;
+    margin-bottom: 1.5rem;
+  }
+  
+  .earn-section {
+    margin-top: 2rem;
+  }
+  
+  .earn-section h2 {
+    font-size: 1.5rem;
+    color: #333;
+  }
+  
+  .earn-section p {
+    font-size: 1rem;
+    color: #555;
+  }
+  

--- a/src/pages/Earn/Earn.js
+++ b/src/pages/Earn/Earn.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import './Earn.css';
+import Header from '../../components/Common/Header';
+
+function Earn() {
+  return (
+    <>
+    <Header/>
+    <div className="earn-container">
+      <h1>Earn with Crypto</h1>
+      <p className="earn-description">
+        Explore ways to earn passive income with crypto! Whether you're looking to stake your assets, lend them to earn interest, or participate in rewards programs, there are various ways to increase your holdings.
+      </p>
+
+      <section className="earn-section">
+        <h2>1. Staking</h2>
+        <p>
+          Staking allows you to earn rewards by locking up your cryptocurrency to support network operations like validating transactions. Popular coins for staking include Ethereum, Cardano, and Polkadot. Staking yields vary based on the network, but it's a simple way to earn while holding your assets.
+        </p>
+      </section>
+
+      <section className="earn-section">
+        <h2>2. Lending and Borrowing</h2>
+        <p>
+          Crypto lending platforms let you earn interest by lending your assets to other users. Platforms such as Aave, Compound, and BlockFi offer flexible lending options, and you can earn interest depending on the asset and demand in the market.
+        </p>
+      </section>
+
+      <section className="earn-section">
+        <h2>3. Rewards Programs</h2>
+        <p>
+          Many platforms offer reward programs where you can earn extra crypto for specific activities, such as referring friends, trading, or learning about new tokens. For example, Coinbase's Earn program allows users to learn about new projects and earn tokens as they go.
+        </p>
+      </section>
+
+      <section className="earn-section">
+        <h2>4. Yield Farming</h2>
+        <p>
+          Yield farming involves providing liquidity to decentralized finance (DeFi) protocols in exchange for rewards. This is a more advanced way to earn, often with higher potential returns but also higher risks. Platforms like Uniswap and PancakeSwap are popular in the DeFi space.
+        </p>
+      </section>
+    </div>
+    </>
+
+  );
+}
+
+export default Earn;


### PR DESCRIPTION
Implemented a new Earn page with relevant content and styling to provide users with insights on earning opportunities in the crypto space. Updated Footer and App routing to include navigation to the Earn page.

'fixed #465 '   
@vanshchauhan21  done 


https://github.com/user-attachments/assets/50a4d7eb-e32d-49ab-b27a-994595514a8e

