### PR TITLE
Fix content visibility on Portfolio Profit and Loss page

### DIFF
--- a/src/pages/ProfitLoss/ProfitLoss.css
+++ b/src/pages/ProfitLoss/ProfitLoss.css
@@ -1,65 +1,71 @@
 .profit-loss-container {
-    padding: 20px;
-    max-width: 800px;
-    margin: 0 auto;
-    text-align: left;
-    font-family: Arial, sans-serif;
-    border: 2px solid #6610f2;
- margin-top: 1rem;
- margin-bottom: 1rem;
- border-radius: 8px;
-
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: left;
+  font-family: Arial, sans-serif;
+  border: 2px solid #6610f2;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
 }
 
 .title {
-    font-size: 2em;
-    margin-bottom: 1rem;
-    color: #0d6efd;
-    text-align: center;
+  font-size: 2em;
+  margin-bottom: 1rem;
+  color: #0d6efd;
+  text-align: center;
 }
 
 .section {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
+  transition: transform 0.3s ease; /* Add transition for smooth effect */
 }
 
 .section h2 {
-    color: #6610f2;
-    margin-bottom: 0.5rem;
+  color: #6610f2;
+  margin-bottom: 0.5rem;
 }
 
 .formula {
-    /* background: #f9f9f9; */
-    padding: 1rem;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    margin-top: 0.5rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  margin-top: 0.5rem;
 }
 
-
 [data-theme="dark"] .formula {
-    background-color: rgba(58, 128, 233, 0.1);
-    border: 1px solid rgba(58, 128, 233, 0.5);
-    box-shadow: 0 0 10px rgba(58, 128, 233, 0.2);
-  }
-  
-   .formula p,
-  .formula ul li,
-  .section p {
-    color: black;
-    text-shadow: 0 0 1px rgba(255, 255, 255, 0.3);
-    
-  }
-  .section{
-    color: black;
-    text-shadow: 0 0 1px rgba(255, 255, 255, 0.3);
-  }
-  
- 
+  background-color: rgba(58, 128, 233, 0.1);
+  border: 1px solid rgba(58, 128, 233, 0.5);
+  box-shadow: 0 0 10px rgba(58, 128, 233, 0.2);
+}
+
+.formula p,
+.formula ul li,
+.section p {
+  color: black;
+  text-shadow: 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.section {
+  color: black;
+  text-shadow: 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+[data-theme="dark"] .section {
+  background-color: black;
+  color: white;
+}
+
+/* Zoom effect on hover in dark mode */
+[data-theme="dark"] .section:hover {
+  transform: scale(1.01); 
+}
 
 [data-theme="dark"] .formula:hover,
 [data-theme="dark"] .formula:hover p,
 [data-theme="dark"] .formula:hover ul,
 [data-theme="dark"] .formula:hover ul li,
 [data-theme="dark"] .section p:hover {
-  color: #ffffff;
+  color: #ffffff; /* Keep text color white on hover */
 }


### PR DESCRIPTION
#546  Fixed

Addressed a severe content visibility issue on the Portfolio Profit and Loss page, where crucial information was unreadable in both dark and light modes. Adjustments were made to the color scheme and contrast to ensure that all data is clearly visible regardless of the selected theme. This fix enhances usability and provides a consistent viewing experience across display modes.




https://github.com/user-attachments/assets/15379a41-27e8-45d9-8e1f-8e877ae0a8eb





