### PR TITLE
fix: Make News section text readable in dark mode

### DIFF
--- a/src/components/Feedback/Feedbacksection.css
+++ b/src/components/Feedback/Feedbacksection.css
@@ -123,6 +123,4 @@
     justify-content: center;
   }
 
-}
 
-}}

--- a/src/components/News.jsx
+++ b/src/components/News.jsx
@@ -26,7 +26,7 @@ function News() {
             <div className="h-[500px] flex flex-col justify-center items-center">
                 {/* Animation */}
                 <Lottie options={defaultOptions} height={250} width={200} />
-                <h1>Sorry, No Items In The News.</h1>
+                <h1 className="text-black dark:text-white">Sorry, No Items In The News.</h1>
                 <div>
                     <a href="/dashboard">
                         <Button text="Dashboard" />


### PR DESCRIPTION
Issue Title
[Frontend issue] Unreadable text in News section during dark mode

Info about the Related Issue
What's the goal of the project?
To create a responsive and visually accessible crypto tracking application that works seamlessly across light and dark themes.


Name
Abhishek Singh

GitHub ID
@Abhishek-singh88


Identify Yourself
SSOC S4 Participant


Closes
Closes: #919 


Describe the Add-ons or Changes You've Made

Fixed the issue where the News section text (“Sorry, No Items In The News.”) was unreadable in dark mode.
Added Tailwind’s dark:text-white utility to ensure text remains visible on dark backgrounds.

Also removed 3 extra closing braces from `src/components/Feedback/Feedbacksection.css
` that were causing a build failure, though unrelated to the main issue.



Type of Change
 Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
I ran the development server locally and:

Switched to dark mode

Navigated to the News section

Confirmed the previously invisible text is now clearly readable


Checklist
 My code follows the guidelines of this project.

 I have performed a self-review of my own code.

 I have commented my code, particularly wherever it was hard to understand.

 I have made corresponding changes to the documentation.

 My changes generate no new warnings.

 I have added things that prove my fix is effective or that my feature works.