### PR TITLE
fix:  Unreadable black text in Watchlist section when dark mode is enabled

### DIFF
--- a/src/pages/Contactus/Contactus.jsx
+++ b/src/pages/Contactus/Contactus.jsx
@@ -95,7 +95,7 @@ const Contactus = () => {
             style={{
               fontWeight: 600,
               fontSize: 30,
-              color: "#000",
+              color: "#8F8D8D",
               margin: 0,
               textAlign: "left",
             }}

--- a/src/pages/Watchlist.js
+++ b/src/pages/Watchlist.js
@@ -95,7 +95,7 @@ function Watchlist() {
         <div className="h-[500px] flex flex-col justify-center items-center">
           {/* Animation */}
           <Lottie options={defaultOptions} height={250} width={200} />
-          <h1>Sorry, No Items In The Watchlist.</h1>
+          <h1 className="text-black dark:text-white" >Sorry, No Items In The Watchlist.</h1>
           <div>
             <a href="/dashboard">
               <Button text="Dashboard" />


### PR DESCRIPTION
[Frontend] Unreadable text watchlist section during dark mode

Name
Abhishek Singh


GitHub ID
@Abhishek-singh88

Identify Yourself
SSOC S4 Participant


Closes
Closes: #916

Describe the Add-ons or Changes You've Made
Fixed the issue where the watchlist and contact section text  was unreadable in dark mode.
Added Tailwind’s dark:text-white utility to ensure text remains visible on dark backgrounds.

